### PR TITLE
add extra useful methods on payment failure

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,7 +15,7 @@ WriteMakefile(
     PREREQ_PM => {
         'Test::More' => 0,
 	'Business::OnlinePayment' => 3.01,
-	'Net::Braintree' => 0.017,
+	'Net::Braintree' => 0.20,
     },
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean               => { FILES => 'Business-OnlinePayment-Braintree-*' },


### PR DESCRIPTION
Also updated Net::Braintree version prereq since errors did not have transaction method until 0.19.1. Latest is 0.20.0 so prereq is 0.20

Patch adds failure_status, result_code and adds order_number on error so that failed transactions can be stored with ref to processor transaction id.
