### PR TITLE
Add support for 'post authorization' action. Bump Net::Braintree prereq ...

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,7 +15,7 @@ WriteMakefile(
     PREREQ_PM => {
         'Test::More' => 0,
 	'Business::OnlinePayment' => 3.01,
-	'Net::Braintree' => 0.020000,
+	'Net::Braintree' => 0.027000,
     },
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean               => { FILES => 'Business-OnlinePayment-Braintree-*' },

--- a/lib/Business/OnlinePayment/Braintree.pm
+++ b/lib/Business/OnlinePayment/Braintree.pm
@@ -87,6 +87,9 @@ sub submit {
     elsif ($action eq 'authorization only') {
         $result = $self->sale(0);
     }
+    elsif ($action eq 'post authorization') {
+        $result = Net::Braintree::Transaction->submit_for_settlement($content{order_number}, $content{amount});
+    }
     elsif ($action eq 'credit' ) {
         $result = Net::Braintree::Transaction->refund($content{order_number}, $content{amount});
     }


### PR DESCRIPTION
...to 0.27.

I got Braintree to support this API call fully in their library, so this BOP action can be supported here, too.